### PR TITLE
Bump version to 0.5.0, fix Home Power, add modbus_test improvements

### DIFF
--- a/custom_components/selfa/const.py
+++ b/custom_components/selfa/const.py
@@ -54,10 +54,18 @@ SENSORS: tuple[SelfaSensorDescription, ...] = (
     ),
     SelfaSensorDescription(
         key="inverter_ac_power",
-        name="Home Power",
+        name="Inverter AC Power",
         register=11016,
         data_type="int32",
         scale=0.001,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SelfaSensorDescription(
+        key="home_power",
+        name="Home Power",
+        register=0,  # virtual — computed by coordinator: PV + Battery - Grid
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/selfa/coordinator.py
+++ b/custom_components/selfa/coordinator.py
@@ -147,4 +147,13 @@ class SelfaCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("Failed to decode %s: %s", sensor.key, e)
                 result[sensor.key] = None
 
+        # Compute home power: P_load = P_pv + P_bat - P_grid_meter
+        pv = result.get("pv_input_power")
+        bat = result.get("battery_power")
+        grid = result.get("grid_meter_power")
+        if pv is not None and bat is not None and grid is not None:
+            result["home_power"] = round(pv + bat - grid, 6)
+        else:
+            result["home_power"] = None
+
         return result

--- a/custom_components/selfa/manifest.json
+++ b/custom_components/selfa/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "selfa",
   "name": "SELFA Inverter",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "config_flow": true,
   "iot_class": "local_polling",
   "requirements": [],

--- a/scripts/modbus_test.py
+++ b/scripts/modbus_test.py
@@ -42,17 +42,38 @@ def i32(regs: list[int]) -> int:
     return val if val < 0x80000000 else val - 0x100000000
 
 
+def i16(reg: int) -> int:
+    return reg if reg < 0x8000 else reg - 0x10000
+
+
 with socket.create_connection((HOST, PORT), timeout=5) as sock:
     pv_regs = read_registers(sock, 11028, 2)
     grid_regs = read_registers(sock, 11000, 2)
+    phase_regs = read_registers(sock, 11009, 6)   # 11009-11014: L1-L3 V+I
+    battery_regs = read_registers(sock, 30258, 2)
     battery_brand_regs = read_registers(sock, 52500, 2)
 
 pv_kw = u32(pv_regs) / 1000
 grid_kw = i32(grid_regs) / 1000
+battery_kw = i32(battery_regs) / 1000
+home_kw = pv_kw + battery_kw - grid_kw
+
+l1_v = phase_regs[0] / 10
+l1_a = phase_regs[1] / 10
+l2_v = phase_regs[2] / 10
+l2_a = phase_regs[3] / 10
+l3_v = phase_regs[4] / 10
+l3_a = phase_regs[5] / 10
+
 battery_brand = battery_brand_regs[0]
 battery_protocol = battery_brand_regs[1]
 
 print(f"PV Input:         {pv_kw:.3f} kW")
-print(f"Grid Meter:       {grid_kw:+.3f} kW  ({'import' if grid_kw > 0 else 'export'})")
+print(f"Grid Meter:       {grid_kw:+.3f} kW  ({'export' if grid_kw > 0 else 'import'})")
+print(f"Battery:          {battery_kw:+.3f} kW  ({'discharge' if battery_kw > 0 else 'charge'})")
+print(f"Home Power:       {home_kw:.3f} kW  (PV + Bat - Grid)")
+print(f"L1:               {l1_v:.1f} V  {l1_a:.1f} A")
+print(f"L2:               {l2_v:.1f} V  {l2_a:.1f} A")
+print(f"L3:               {l3_v:.1f} V  {l3_a:.1f} A")
 print(f"Battery Brand:    {battery_brand}")
 print(f"Battery Protocol: {battery_protocol}")


### PR DESCRIPTION
  - Fix Home Power: computed as PV + Battery - Grid (was incorrectly reading P_AC register which is inverter output, not home consumption)
  - Rename inverter_ac_power label to Inverter AC Power
  - scripts/modbus_test.py: add battery power, home power, L1/L2/L3 V+I, fix grid import/export label

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>