### PR TITLE
Add EMS battery power scheduling control (reg 50207)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,10 +45,12 @@ jobs:
             RANGE="${LAST_TAG}..HEAD"
           fi
 
-          NOTES=$(git log --format="%B" $RANGE \
-            | grep -oP '(?<=RelNotes: ).*' \
-            | sed 's/^/- /' \
-            || true)
+          NOTES=$(git log --format="%B" $RANGE | awk '
+            /^RelNotes: / { sub(/^RelNotes: /, "- "); print; next }
+            /^RelNotes:$/  { capture=1; next }
+            capture && /^[[:space:]]*$/ { capture=0; next }
+            capture { print }
+          ' || true)
 
           if [ -z "$NOTES" ]; then
             NOTES="_No release notes in commit messages._"

--- a/custom_components/selfa/const.py
+++ b/custom_components/selfa/const.py
@@ -384,6 +384,16 @@ SENSORS: tuple[SelfaSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SelfaSensorDescription(
+        key="battery_power_sched",
+        name="Battery Power Scheduling",
+        register=50207,
+        data_type="int16",
+        scale=0.01,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SelfaSensorDescription(
         key="working_mode",
         name="Working Mode",
         register=50000,

--- a/custom_components/selfa/coordinator.py
+++ b/custom_components/selfa/coordinator.py
@@ -39,6 +39,7 @@ REGISTER_BATCHES = [
     (25100, 4),  # export limit: enable (25100), value (25103)
     (33000, 4),  # SOC, SOH, BMS status, BMS temp (33000-33003)
     (50000, 10), # working mode (50000), import limit enable (50007), value (50009)
+    (50207, 1),  # EMS battery power scheduling (50207)
     (52500, 1),  # battery brand (52500)
 ]
 

--- a/custom_components/selfa/manifest.json
+++ b/custom_components/selfa/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "selfa",
   "name": "SELFA Inverter",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "config_flow": true,
   "iot_class": "local_polling",
   "requirements": [],

--- a/custom_components/selfa/number.py
+++ b/custom_components/selfa/number.py
@@ -23,6 +23,17 @@ class SelfaNumberDescription(NumberEntityDescription):
 
 NUMBERS: tuple[SelfaNumberDescription, ...] = (
     SelfaNumberDescription(
+        key="battery_power_sched",
+        name="Battery Power Scheduling",
+        register=50207,
+        native_min_value=-20.0,
+        native_max_value=20.0,
+        native_step=0.1,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        mode=NumberMode.BOX,
+        raw_from_value=lambda v: int(v * 100) & 0xFFFF,
+    ),
+    SelfaNumberDescription(
         key="export_limit_value",
         name="Export Limit Value",
         register=25103,

--- a/scripts/modbus_test.py
+++ b/scripts/modbus_test.py
@@ -98,6 +98,8 @@ with socket.create_connection((HOST, PORT), timeout=5) as sock:
     battery_regs      = read_registers(sock, 30258, 2)
     battery_brand_regs = read_registers(sock, 52500, 2)
     working_mode_regs = read_registers(sock, 50000, 1)
+    batt_power_sched_regs = read_registers(sock, 50207, 1)
+    bms_status_regs = read_registers(sock, 53508, 1)
 
     # Export limit area (confirmed)
     limit_regs  = read_registers(sock, 25100, 20)   # 25100–25119
@@ -157,6 +159,13 @@ working_mode = WORKING_MODES_DISPLAY.get(working_mode_raw, f"Unknown ({working_m
 
 battery_brand    = battery_brand_regs[0]
 battery_protocol = battery_brand_regs[1]
+batt_power_sched_kw = i16(batt_power_sched_regs[0]) / 100
+bms_status_raw = bms_status_regs[0]
+bms_discharge_ongrid  = bool(bms_status_raw & (1 << 9))
+bms_discharge_offgrid = bool(bms_status_raw & (1 << 8))
+bms_charge_cmd        = bool(bms_status_raw & (1 << 10))
+bms_force_charge      = bool(bms_status_raw & (1 << 11))
+bms_running_status    = bms_status_raw & 0xFF
 
 export_enable = limit_regs[REG_EXPORT_ENABLE - 25100]
 export_value  = limit_regs[REG_EXPORT_VALUE  - 25100] / 10     # kW
@@ -181,13 +190,12 @@ print(f"Import Limit:     {'ON' if import_enable else 'OFF'}  {import_value:.1f}
       f"  (enable={REG_IMPORT_ENABLE}?, value={REG_IMPORT_VALUE})")
 print(f"Battery Brand:    {battery_brand}")
 print(f"Battery Protocol: {battery_protocol}")
+print(f"Batt Pwr Sched:   {batt_power_sched_kw:+.2f} kW  (50207, +discharge/-charge)")
+BMS_RUNNING = {0: "Sleep", 1: "Charge", 2: "Discharge", 3: "Standby", 4: "Fault"}
+print(f"BMS Status:       0x{bms_status_raw:04x}  (53508)"
+      f"  discharge_ongrid={int(bms_discharge_ongrid)}"
+      f"  discharge_offgrid={int(bms_discharge_offgrid)}"
+      f"  charge={int(bms_charge_cmd)}"
+      f"  force_charge={int(bms_force_charge)}"
+      f"  running={BMS_RUNNING.get(bms_running_status, bms_running_status)}")
 
-print()
-print("-- raw export limit registers 25100–25119 --")
-for i, val in enumerate(limit_regs):
-    print(f"  {25100 + i}: {val}  (0x{val:04x})")
-
-print()
-print("-- raw import limit registers 50005–50014 (toggle import limit in app to identify enable reg) --")
-for i, val in enumerate(import_regs):
-    print(f"  {50005 + i}: {val}  (0x{val:04x})")


### PR DESCRIPTION
- Add Battery Power Scheduling sensor and number entity (reg 50207, I16, kW) to allow controlling battery charge/discharge in EMS Battery Control mode
- Positive value = discharge, negative = charge, 0 = idle (no discharge)
- Add reg 53508 (BMS status) and 50207 read to modbus_test.py diagnostic script
- Bump version to 0.13.0

RelNotes:
- **New**: Battery Power Scheduling control (EMS mode, reg 50207) — set discharge/charge power or disable battery discharge entirely
- **New**: BMS status register (53508) visible in modbus_test.py diagnostic script